### PR TITLE
修复items变更后，长度没更新，导致无法向上滑动的问题！

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ export default class PickerAndroid extends React.Component{
 
 	componentWillReceiveProps(nextProps){
 		this.setState(this._stateFromProps(nextProps));
+		this.length = this.state.items.length;
 	}
 
 	_stateFromProps(props){


### PR DESCRIPTION
修复items变更后，长度没更新，导致无法向上滑动的问题！
