### PR TITLE
add onPanResponderTerminationRequest handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ export default class PickerAndroid extends Component{
 
 	componentWillMount(){
 		this._panResponder = PanResponder.create({
+			onPanResponderTerminationRequest: (evt, gestureState) => false,
 			onMoveShouldSetPanResponder: (evt, gestureState) => true,
 			onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
 			onPanResponderRelease: this._handlePanResponderRelease.bind(this),


### PR DESCRIPTION
This will fix issues when a parent component 'steals' swipe events
